### PR TITLE
Upgrade rasterio to 1.3b1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 
 requirements = ['numpy',
                 'scipy',
-                'rasterio[s3] @ https://github.com/rasterio/rasterio/archive/refs/tags/1.3a3.tar.gz',
+                'rasterio[s3] @ https://github.com/rasterio/rasterio/archive/refs/tags/1.3b1.tar.gz',
                 'utm',
                 'pyproj>=2.0.2,<3.0.0',
                 'beautifulsoup4[lxml]',


### PR DESCRIPTION
This version of rasterio is needed to be able to read a CRS that contains geoid information, without killing the kernel.