### PR TITLE
Skip tiles when rectification fails

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -604,9 +604,15 @@ def main(user_cfg, start_from=0):
         if cfg['max_processes_stereo_matching'] is not None:
             nb_workers_stereo = cfg['max_processes_stereo_matching']
         else:
-            nb_workers_stereo = nb_workers
-        parallel.launch_calls(stereo_matching, tiles_pairs, nb_workers_stereo,
-                              timeout=timeout)
+            # Set the number of stereo workers to 2/3 of the number of cores by default
+            nb_workers_stereo = min(1, int(2 * (nb_workers / 3)))
+        try:
+            parallel.launch_calls(stereo_matching, tiles_pairs, nb_workers_stereo,
+                          timeout=timeout)
+        except subprocess.CalledProcessError as e:
+            print(f'ERROR: stereo matching failed. In case this is due too little RAM set '
+                  f'"max_processes_stereo_matching" to a lower value (currently set to: {nb_workers_stereo}).')
+            raise e
 
     if start_from <= 5:
         if n > 2:

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -632,7 +632,8 @@ def main(user_cfg, start_from=0):
                                   timeout=timeout)
             tiles = [t for t in tiles if t is not None]
             if len(tiles) != num_tiles:
-                print(f'WARNING: {num_tiles-len(tiles)}/{num_tiles} tiles failed when applying homography and will be skipped.')
+                print(f'WARNING: {len(tiles)-num_tiles}/{num_tiles} tiles failed when applying homography '
+                      'and will be skipped.')
 
     # local-dsm-rasterization step:
     if start_from <= 6:

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import subprocess
 import sys
 import os.path
 import json
@@ -146,13 +146,17 @@ def rectification_pair(tile, i):
 
     rect1 = os.path.join(out_dir, 'rectified_ref.tif')
     rect2 = os.path.join(out_dir, 'rectified_sec.tif')
-    H1, H2, disp_min, disp_max = rectification.rectify_pair(img1, img2,
-                                                            rpc1, rpc2,
-                                                            x, y, w, h,
-                                                            rect1, rect2, A, m,
-                                                            method=cfg['rectification_method'],
-                                                            hmargin=cfg['horizontal_margin'],
-                                                            vmargin=cfg['vertical_margin'])
+    try:
+        H1, H2, disp_min, disp_max = rectification.rectify_pair(img1, img2,
+                                                                rpc1, rpc2,
+                                                                x, y, w, h,
+                                                                rect1, rect2, A, m,
+                                                                method=cfg['rectification_method'],
+                                                                hmargin=cfg['horizontal_margin'],
+                                                                vmargin=cfg['vertical_margin'])
+    except subprocess.CalledProcessError as e:
+        print(f'ERROR: {e} while rectifying tile {out_dir}')
+        return None
     np.savetxt(os.path.join(out_dir, 'H_ref.txt'), H1, fmt='%12.6f')
     np.savetxt(os.path.join(out_dir, 'H_sec.txt'), H2, fmt='%12.6f')
     np.savetxt(os.path.join(out_dir, 'disp_min_max.txt'), [disp_min, disp_max],
@@ -161,7 +165,7 @@ def rectification_pair(tile, i):
     if cfg['clean_intermediate']:
         common.remove(os.path.join(out_dir, 'pointing.txt'))
         common.remove(os.path.join(out_dir, 'sift_matches.txt'))
-
+    return tile
 
 def stereo_matching(tile, i):
     """
@@ -586,8 +590,13 @@ def main(user_cfg, start_from=0):
     # rectification step:
     if start_from <= 3:
         print('3) rectifying tiles...')
-        parallel.launch_calls(rectification_pair, tiles_pairs, nb_workers,
+        num_tiles = len(tiles)
+        tiles = parallel.launch_calls(rectification_pair, tiles_pairs, nb_workers,
                               timeout=timeout)
+        tiles = [t for t in tiles if t is not None]
+        if num_tiles != len(tiles):
+            print(f'WARNING: {num_tiles-len(tiles)}/{num_tiles} tiles were not rectified. Skipping.')
+            tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]
 
     # matching step:
     if start_from <= 4:
@@ -623,6 +632,7 @@ def main(user_cfg, start_from=0):
             num_tiles = len(tiles)
             tiles = parallel.launch_calls(disparity_to_ply, tiles, nb_workers,
                                   timeout=timeout)
+            tiles = [t for t in tiles if t is not None]
             if len(tiles) != num_tiles:
                 print(f'WARNING: {num_tiles-len(tiles)}/{num_tiles} tiles failed when applying homography and will be skipped.')
 

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -146,17 +146,14 @@ def rectification_pair(tile, i):
 
     rect1 = os.path.join(out_dir, 'rectified_ref.tif')
     rect2 = os.path.join(out_dir, 'rectified_sec.tif')
-    try:
-        H1, H2, disp_min, disp_max = rectification.rectify_pair(img1, img2,
-                                                                rpc1, rpc2,
-                                                                x, y, w, h,
-                                                                rect1, rect2, A, m,
-                                                                method=cfg['rectification_method'],
-                                                                hmargin=cfg['horizontal_margin'],
-                                                                vmargin=cfg['vertical_margin'])
-    except subprocess.CalledProcessError as e:
-        print(f'ERROR: {e} while rectifying tile {out_dir}')
-        return None
+    H1, H2, disp_min, disp_max = rectification.rectify_pair(img1, img2,
+                                                            rpc1, rpc2,
+                                                            x, y, w, h,
+                                                            rect1, rect2, A, m,
+                                                            method=cfg['rectification_method'],
+                                                            hmargin=cfg['horizontal_margin'],
+                                                            vmargin=cfg['vertical_margin'])
+
     np.savetxt(os.path.join(out_dir, 'H_ref.txt'), H1, fmt='%12.6f')
     np.savetxt(os.path.join(out_dir, 'H_sec.txt'), H2, fmt='%12.6f')
     np.savetxt(os.path.join(out_dir, 'disp_min_max.txt'), [disp_min, disp_max],
@@ -165,7 +162,6 @@ def rectification_pair(tile, i):
     if cfg['clean_intermediate']:
         common.remove(os.path.join(out_dir, 'pointing.txt'))
         common.remove(os.path.join(out_dir, 'sift_matches.txt'))
-    return tile
 
 def stereo_matching(tile, i):
     """
@@ -590,13 +586,9 @@ def main(user_cfg, start_from=0):
     # rectification step:
     if start_from <= 3:
         print('3) rectifying tiles...')
-        num_tiles = len(tiles)
-        tiles = parallel.launch_calls(rectification_pair, tiles_pairs, nb_workers,
+        parallel.launch_calls(rectification_pair, tiles_pairs, nb_workers,
                               timeout=timeout)
         tiles = [t for t in tiles if t is not None]
-        if num_tiles != len(tiles):
-            print(f'WARNING: {num_tiles-len(tiles)}/{num_tiles} tiles were not rectified. Skipping.')
-            tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]
 
     # matching step:
     if start_from <= 4:


### PR DESCRIPTION
Skip tile when rectification fails. Which is actually where s2p currently fails for [this](https://dagster.stage-elm.overstory.ai/instance/runs/52632137-9cbf-4558-9daf-262d4b794d5a?logKey=s2p_processor) run.