### PR TITLE
Updating rasterio version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 
 requirements = ['numpy',
                 'scipy',
-                'rasterio[s3] @ https://github.com/rasterio/rasterio/archive/refs/tags/1.3b1.tar.gz',
+                'rasterio[s3] @ https://github.com/rasterio/rasterio/archive/refs/tags/1.3.3.tar.gz',
                 'utm',
                 'pyproj>=2.0.2,<3.0.0',
                 'beautifulsoup4[lxml]',


### PR DESCRIPTION
Upgrading because rasterio.fillnodata has a bug at versions below 1.3.2, this is to allow for s2p_pipelines to have the same version as s2p