### PR TITLE
Remove deleted tiles from neighborhood_dirs

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -72,7 +72,7 @@ def remove_missing_tiles(tiles):
     for i in range(len(tiles_new)):
         tiles_new[i]['neighborhood_dirs']  = [d for d in tiles_new[i]['neighborhood_dirs'] if d not in deleted_tiles]
     
-    tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]
+    tiles_pairs = [(t, i) for i in range(1, n) for t in tiles_new]
     return tiles_new, tiles_pairs
 
 

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -610,6 +610,7 @@ def main(user_cfg, start_from=0):
     if start_from <= 4:
         # Check which tiles were rectified correctly, and skip tiles that have missing files
         tiles_new = []
+        deleted_tiles = []
         for tile in tiles:
             paths = []
             for i in range(1, n):
@@ -622,9 +623,14 @@ def main(user_cfg, start_from=0):
             if missing > 0:
                 print(f"WARNING: tile {tile['dir']} is missing {missing}/{len(paths)} "
                       "input files for stereo matching, skipping...")
+                deleted_tiles.append(tile['dir']])
                 continue
             tiles_new.append(tile)
         tiles = tiles_new
+        # Remove deleted tiles from neighborhood_dirs
+        for i in range(len(tiles)):
+            tiles[i]['neighborhood_dirs']  = [d for d in tiles[i]['neighborhood_dirs'] if d not in deleted_tiles]
+
         tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]
 
         if cfg['max_processes_stereo_matching'] is not None:

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -69,7 +69,7 @@ def remove_missing_tiles(tiles):
         tiles_new.append(tile)
 
     # Remove deleted tiles from neighborhood_dirs
-    for i in range(len(tiles)):
+    for i in range(len(tiles_new)):
         tiles_new[i]['neighborhood_dirs']  = [d for d in tiles_new[i]['neighborhood_dirs'] if d not in deleted_tiles]
     
     tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -621,9 +621,10 @@ def main(user_cfg, start_from=0):
                 ]
             missing = sum(not os.path.exists(p) for p in paths)
             if missing > 0:
-                print(f"WARNING: tile {tile['dir']} is missing {missing}/{len(paths)} "
+                relative_path = os.path.join('../../..', initialization.get_tile_dir(*tile['coordinates']))
+                print(f"WARNING: tile {relative_path} is missing {missing}/{len(paths)} "
                       "input files for stereo matching, skipping...")
-                deleted_tiles.append(os.path.join('../../..', tile['dir']))
+                deleted_tiles.append(relative_path)
                 continue
             tiles_new.append(tile)
         tiles = tiles_new

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -623,7 +623,7 @@ def main(user_cfg, start_from=0):
             if missing > 0:
                 print(f"WARNING: tile {tile['dir']} is missing {missing}/{len(paths)} "
                       "input files for stereo matching, skipping...")
-                deleted_tiles.append(tile['dir']])
+                deleted_tiles.append(tile['dir'])
                 continue
             tiles_new.append(tile)
         tiles = tiles_new

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -623,7 +623,7 @@ def main(user_cfg, start_from=0):
             if missing > 0:
                 print(f"WARNING: tile {tile['dir']} is missing {missing}/{len(paths)} "
                       "input files for stereo matching, skipping...")
-                deleted_tiles.append(tile['dir'])
+                deleted_tiles.append(os.path.join('../../..', tile['dir']))
                 continue
             tiles_new.append(tile)
         tiles = tiles_new

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -48,6 +48,7 @@ from s2p import visualisation
 
 def remove_missing_tiles(tiles):
     """Remove tiles where any of the rectified images is missing (also remove from neighborhood_dirs)."""
+    n = len(cfg['images'])
     tiles_new = []
     deleted_tiles = []
     for tile in tiles:
@@ -70,7 +71,9 @@ def remove_missing_tiles(tiles):
     # Remove deleted tiles from neighborhood_dirs
     for i in range(len(tiles)):
         tiles_new[i]['neighborhood_dirs']  = [d for d in tiles_new[i]['neighborhood_dirs'] if d not in deleted_tiles]
-    return tiles_new
+    
+    tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]
+    return tiles_new, tiles_pairs
 
 
 def check_missing_sift(tiles_pairs):
@@ -636,8 +639,7 @@ def main(user_cfg, start_from=0):
     # matching step:
     if start_from <= 4:
         # Check which tiles were rectified correctly, and skip tiles that have missing files
-        tiles = remove_missing_tiles(tiles)
-        tiles_pairs = [(t, i) for i in range(1, n) for t in tiles]
+        tiles, tiles_pairs = remove_missing_tiles(tiles)
 
         if cfg['max_processes_stereo_matching'] is not None:
             nb_workers_stereo = cfg['max_processes_stereo_matching']

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras_require = {
 }
 
 setup(name="s2p",
-      version="1.3.5",
+      version="1.3.6",
       description="Satellite Stereo Pipeline.",
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ requirements = ['numpy',
                 'plyflatten>=0.2.0',
                 'ransac',
                 'rpcm @ https://github.com/20treeAI/rpcm/archive/refs/tags/v1.4.8.tar.gz',
-                'srtm4>=1.1.2',
+                'srtm4 @ https://github.com/20treeAI/srtm4/archive/refs/tags/1.2.4.tar.gz',
                 'requests']
 
 extras_require = {


### PR DESCRIPTION
Sometimes for certain tiles the coordinates within the secondary image are negative/zero which causes an error. This solves this by removing tiles where this is the case.

Testing in: https://github.com/20treeAI/s2p_pipelines/pull/66