### PR TITLE
Increase number of stereo workers

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -89,7 +89,7 @@ def check_missing_sift(tiles_pairs):
         print(" --- ")
         print(f"WARNING: missing {len(missing_sift)}/{len(tiles_pairs)} "
               "SIFT matches, this may deteriorate output quality")
-        print(" --- ")
+
 
 def pointing_correction(tile, i):
     """
@@ -644,16 +644,7 @@ def main(user_cfg, start_from=0):
         if cfg['max_processes_stereo_matching'] is not None:
             nb_workers_stereo = cfg['max_processes_stereo_matching']
         else:
-            # Set the number of stereo workers to the number of workers divided
-            # by a certain amount depending on the tile_size and number of tiles
-            # this should be a generally safe number of workers.
-            divider = 2 * (cfg['tile_size'] / 800.0) * (cfg['tile_size'] / 800.0)
-            divider *= (len(tiles_pairs) / 500.0)
-            if cfg['matching_algorithm'] == 'mgm_multi':
-                nb_workers_stereo = int(min(nb_workers, max(1, int(nb_workers / divider))))
-            else:
-                # For non mgm_multi don't use less than 2/3 of the workers (much less RAM intensive)
-                nb_workers_stereo = int(min(nb_workers, max(((2 / 3) * nb_workers), nb_workers / divider)))
+            nb_workers_stereo = nb_workers
         try:
 
             print(f'4) running stereo matching using {nb_workers_stereo} workers...')

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras_require = {
 }
 
 setup(name="s2p",
-      version="1.3.6",
+      version="1.3.7",
       description="Satellite Stereo Pipeline.",
       long_description=readme(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
It seems that reducing the number of stereo processes is not necessary anymore because the amount of RAM used seems to be reduced somehow. This is based on observing many s2p runs over the past few weeks, that are all using little RAM. I have no idea what led to reduced RAM usage.

This PR removes complicated code for determining an appropriate number of stereo workers,  and instead uses the `nb_workers` by default and let the user override this if needed.