### PR TITLE
Reduce detault nb_workers_stereo to half the nb_workers

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -644,7 +644,7 @@ def main(user_cfg, start_from=0):
         if cfg['max_processes_stereo_matching'] is not None:
             nb_workers_stereo = cfg['max_processes_stereo_matching']
         else:
-            nb_workers_stereo = nb_workers
+            nb_workers_stereo = min(1, int(nb_workers / 2.0))
         try:
 
             print(f'4) running stereo matching using {nb_workers_stereo} workers...')

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras_require = {
 }
 
 setup(name="s2p",
-      version="1.3.7",
+      version="1.3.8",
       description="Satellite Stereo Pipeline.",
       long_description=readme(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
It turned out that RAM usage can still be an issue, let's try to set it to half the `nb_workers` by default.