### PR TITLE
Don't reimport the cfg

### DIFF
--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import subprocess
 import sys
+import copy
 import os.path
 import json
 import datetime
@@ -45,6 +46,7 @@ from s2p import ply
 from s2p import triangulation
 from s2p import fusion
 from s2p import visualisation
+from s2p import config
 from s2p.image_coordinates_to_coordinates import matches_to_geojson
 
 
@@ -603,9 +605,8 @@ def main(user_cfg, start_from=0, merge_matches=False):
         user_cfg: user config dictionary
         start_from: the step to start from (default: 0)
     """
-    from s2p.config import cfg
     common.print_elapsed_time.t0 = datetime.datetime.now()
-    cfg = initialization.build_cfg(cfg, user_cfg)
+    cfg = initialization.build_cfg(copy.deepcopy(config.cfg), user_cfg)
     initialization.make_dirs(cfg)
 
     # multiprocessing setup

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -718,7 +718,7 @@ def main(user_cfg, start_from=0, merge_matches=False):
         parallel.launch_calls(plys_to_dsm, tiles, nb_workers, timeout=timeout)
 
     # global-dsm-rasterization step:
-    if start_from <= 7 and cfg['merge_dsm']:
+    if start_from <= 7 and cfg['merge_dsms']:
         print('7) computing global DSM...')
         global_dsm(tiles)
         

--- a/s2p/__init__.py
+++ b/s2p/__init__.py
@@ -718,7 +718,7 @@ def main(user_cfg, start_from=0, merge_matches=False):
         parallel.launch_calls(plys_to_dsm, tiles, nb_workers, timeout=timeout)
 
     # global-dsm-rasterization step:
-    if start_from <= 7:
+    if start_from <= 7 and cfg['merge_dsm']:
         print('7) computing global DSM...')
         global_dsm(tiles)
         

--- a/s2p/config.py
+++ b/s2p/config.py
@@ -26,6 +26,9 @@ cfg['clean_intermediate'] = False
 # switch to True if you want to process the whole image
 cfg['full_img'] = False
 
+# set to False if you don't want to merge the dsm tiles
+cfg['merge_dsms'] = True
+
 # s2p processes the images tile by tile. The tiles are squares cropped from the
 # reference image. The width and height of the tiles are given by this param, in pixels.
 cfg['tile_size'] = 800

--- a/s2p/parallel.py
+++ b/s2p/parallel.py
@@ -7,7 +7,6 @@ import traceback
 import multiprocessing
 
 from s2p import common
-from s2p.config import cfg
 
 
 def show_progress(a):
@@ -31,10 +30,10 @@ def show_progress(a):
     sys.stdout.flush()
 
 
-def tilewise_wrapper(fun, *args, **kwargs):
+def tilewise_wrapper(fun, debug, *args, **kwargs):
     """
     """
-    if not cfg['debug']:  # redirect stdout and stderr to log file
+    if not debug:  # redirect stdout and stderr to log file
         f = open(kwargs['stdout'], 'a')
         sys.stdout = f
         sys.stderr = f
@@ -47,7 +46,7 @@ def tilewise_wrapper(fun, *args, **kwargs):
         raise
 
     common.garbage_cleanup()
-    if not cfg['debug']:  # close logs
+    if not debug:  # close logs
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__
         f.close()
@@ -56,7 +55,7 @@ def tilewise_wrapper(fun, *args, **kwargs):
 
 
 def launch_calls(fun, list_of_args, nb_workers, *extra_args, tilewise=True,
-                 timeout=600):
+                 timeout=600, debug=False):
     """
     Run a function several times in parallel with different given inputs.
 
@@ -90,7 +89,7 @@ def launch_calls(fun, list_of_args, nb_workers, *extra_args, tilewise=True,
                 log = os.path.join(x[0]['dir'], 'pair_%d' % x[1], 'stdout.log')
             else:  # we expect x = tile_dictionary
                 log = os.path.join(x['dir'], 'stdout.log')
-            args = (fun,) + args
+            args = (fun, debug) + args
             results.append(pool.apply_async(tilewise_wrapper, args=args,
                                             kwds={'stdout': log},
                                             callback=show_progress))

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ extras_require = {
 }
 
 setup(name="s2p",
-      version="1.5.4",
+      version="1.6.0",
       description="Satellite Stereo Pipeline.",
       long_description=readme(),
       long_description_content_type='text/markdown',

--- a/tests/end2end_test.py
+++ b/tests/end2end_test.py
@@ -56,11 +56,6 @@ def compare_dsm(computed, expected, absmean_tol, percentile_tol):
 
 
 def end2end(config_file, ref_dsm, absmean_tol=0.025, percentile_tol=1.):
-
-    # TODO: this is ugly, and will be fixed once we'll have implemented a better
-    # way to control the config parameters
-    if 'out_crs' in s2p.cfg: del s2p.cfg['out_crs']
-
     test_cfg = s2p.read_config_file(config_file)
     s2p.main(test_cfg)
 

--- a/tests/end2end_test.py
+++ b/tests/end2end_test.py
@@ -5,9 +5,9 @@
 import os
 import sys
 import glob
+import rasterio
 import numpy as np
 from plyflatten import plyflatten_from_plyfiles_list
-import pytest
 
 import s2p
 from s2p import common
@@ -61,6 +61,9 @@ def end2end(config_file, ref_dsm, absmean_tol=0.025, percentile_tol=1.):
 
     outdir = test_cfg['out_dir']
 
+    out_dsm = os.path.join(outdir, 'dsm.tif')
+    assert os.path.exists(out_dsm)
+    assert rasterio.open(out_dsm).crs == rasterio.open(ref_dsm).crs
     computed = common.rio_read_as_array_with_nans(os.path.join(outdir, 'dsm.tif'))
     expected = common.rio_read_as_array_with_nans(ref_dsm)
 

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -112,7 +112,7 @@ def test_rpc_dict(data, mocks):
 def test_roi_geojson(data):
     tmp_config, _, _, _ = data
     from s2p.config import cfg
-    user_cfg = s2p.read_config_file(cfg, tmp_config)
+    user_cfg = s2p.read_config_file(tmp_config)
 
     user_cfg["roi_geojson"] = {
       "coordinates" : [

--- a/tests/initialization_test.py
+++ b/tests/initialization_test.py
@@ -47,10 +47,10 @@ def test_no_rpc(data, mocks):
     Initialize s2p with no `rpc` key.
     The RPCs should be read from the geotiff tags.
     """
-
+    from s2p.config import cfg
     tmp_config, _, _, _ = data
     user_cfg = s2p.read_config_file(tmp_config)
-    s2p.initialization.build_cfg(user_cfg)
+    cfg = s2p.initialization.build_cfg(cfg, user_cfg)
 
     rpcm.rpc_from_geotiff.assert_called()
     assert rpcm.rpc_from_geotiff.call_count == 2
@@ -77,8 +77,9 @@ def test_rpc_path(data, mocks):
     with open(tmp_config, "w") as f:
         json.dump(cfg, f)
 
+    from s2p.config import cfg
     user_cfg = s2p.read_config_file(tmp_config)
-    s2p.initialization.build_cfg(user_cfg)
+    cfg = s2p.initialization.build_cfg(cfg, user_cfg)
 
     rpcm.rpc_from_geotiff.assert_not_called()
     rpcm.rpc_from_rpc_file.assert_called()
@@ -101,7 +102,8 @@ def test_rpc_dict(data, mocks):
         json.dump(cfg, f)
 
     user_cfg = s2p.read_config_file(tmp_config)
-    s2p.initialization.build_cfg(user_cfg)
+    from s2p.config import cfg
+    cfg = s2p.initialization.build_cfg(cfg, user_cfg)
 
     rpcm.rpc_from_geotiff.assert_not_called()
     rpcm.rpc_from_rpc_file.assert_not_called()
@@ -109,7 +111,8 @@ def test_rpc_dict(data, mocks):
 
 def test_roi_geojson(data):
     tmp_config, _, _, _ = data
-    user_cfg = s2p.read_config_file(tmp_config)
+    from s2p.config import cfg
+    user_cfg = s2p.read_config_file(cfg, tmp_config)
 
     user_cfg["roi_geojson"] = {
       "coordinates" : [
@@ -138,6 +141,6 @@ def test_roi_geojson(data):
       ],
       "type" : "Polygon"
     }
-
-    s2p.initialization.build_cfg(user_cfg)
+    from s2p.config import cfg
+    cfg = s2p.initialization.build_cfg(cfg, user_cfg)
     assert user_cfg["roi"] == {'x': 150, 'y': 150, 'w': 700, 'h': 700}

--- a/tests/triangulation_test.py
+++ b/tests/triangulation_test.py
@@ -23,10 +23,11 @@ def test_disparity_to_ply(tmp_path, out_crs):
     config_file = data_path(os.path.join("input_pair", "config.json"))
     test_cfg = read_config_file(config_file)
     test_cfg["out_crs"] = out_crs
-    build_cfg(test_cfg)
+    from s2p.config import cfg
+    cfg = build_cfg(cfg, test_cfg)
 
     tile = {"coordinates": [500, 150, 350, 350], "dir": tile_dir}
-    disparity_to_ply(tile)
+    disparity_to_ply(tile, cfg)
 
     _, comments = read_3d_point_cloud_from_ply(os.path.join(tile_dir, "cloud.ply"))
     expected_crs = out_crs or "epsg:32740"


### PR DESCRIPTION
In certain situations the `cfg` parameter can be overwritten due to it being reimported. This fixes it by always passing the `cfg` instead of relying on the variable being unchanged and not importing it more than once.