### PR TITLE
fix: this functions has internal subprocess calls

### DIFF
--- a/s2p/initialization.py
+++ b/s2p/initialization.py
@@ -347,7 +347,6 @@ def is_this_tile_useful(x, y, w, h, images, images_sizes, border_margin, cfg):
     mask = masking.image_tile_mask(x, y, w, h, roi_msk, cld_msk, wat_msk,
                                    images_sizes[0], border_margin=border_margin, temporary_dir=cfg['temporary_dir'])
     if not mask.any():
-
         return False, None
     return True, mask
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ extras_require = {
 }
 
 setup(name="s2p",
-      version="1.6.2",
+      version="1.6.3",
       description="Satellite Stereo Pipeline.",
       long_description=readme(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
This function has several internal subprocess calls. By claiming all processes on this level, a major slowdown is introduced.

This ensures only half of the max cpus is used.

In my testing, this makes the `tiles_full_info` step twice as fast.