### PR TITLE
feat: enable native compilation on Mac OS / Apple Silicon

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,6 @@
 	path = 3rdparty/msmw3
 	url = https://github.com/cmla/msmw3
 	ignore = untracked
+[submodule "3rdparty/sse2neon"]
+	path = 3rdparty/sse2neon
+	url = https://github.com/DLTcollab/sse2neon

--- a/.gitmodules
+++ b/.gitmodules
@@ -35,6 +35,3 @@
 	path = 3rdparty/msmw3
 	url = https://github.com/cmla/msmw3
 	ignore = untracked
-[submodule "3rdparty/sse2neon"]
-	path = 3rdparty/sse2neon
-	url = https://github.com/DLTcollab/sse2neon

--- a/3rdparty/homography.patch
+++ b/3rdparty/homography.patch
@@ -1,0 +1,57 @@
+diff --git a/3rdparty/homography/LibHomography/Splines.h b/3rdparty/homography/LibHomography/Splines.h
+index 56a36f1..46a123d 100644
+--- a/3rdparty/homography/LibHomography/Splines.h
++++ b/3rdparty/homography/LibHomography/Splines.h
+@@ -5,8 +5,7 @@
+ //! Global includes
+ #include <cstdlib>
+ #include <cmath>
+-#include <xmmintrin.h>
+-#include <x86intrin.h>
++#include "../../sse2neon/sse2neon.h"
+ 
+ 
+ //! Local includes
+diff --git a/3rdparty/homography/LibImages/LibImages.cpp b/3rdparty/homography/LibImages/LibImages.cpp
+index 7c1f6f5..fd75fb4 100644
+--- a/3rdparty/homography/LibImages/LibImages.cpp
++++ b/3rdparty/homography/LibImages/LibImages.cpp
+@@ -14,8 +14,7 @@
+ #ifdef _OPENMP
+ #include <omp.h>
+ #endif
+-#include <xmmintrin.h>
+-#include <x86intrin.h>
++#include "../../sse2neon/sse2neon.h"
+ #include <cmath>
+ #include <algorithm>
+ #include <cstring>
+diff --git a/3rdparty/homography/LibImages/LibImages.h b/3rdparty/homography/LibImages/LibImages.h
+index 51233a3..8ae589d 100644
+--- a/3rdparty/homography/LibImages/LibImages.h
++++ b/3rdparty/homography/LibImages/LibImages.h
+@@ -5,8 +5,7 @@
+ #include <stdlib.h>
+ #include <string>
+ #include <vector>
+-#include <xmmintrin.h>
+-#include <x86intrin.h>
++#include "../../sse2neon/sse2neon.h"
+ 
+ //! Local includes
+ 
+diff --git a/3rdparty/homography/Utilities/Utilities.h b/3rdparty/homography/Utilities/Utilities.h
+index cc80a22..ee45bf9 100644
+--- a/3rdparty/homography/Utilities/Utilities.h
++++ b/3rdparty/homography/Utilities/Utilities.h
+@@ -8,8 +8,8 @@
+ #include <sstream>
+ #include <iostream>
+ #include <iomanip>
+-#include <xmmintrin.h>
+-#include <x86intrin.h>
++#include "../../sse2neon/sse2neon.h"
++
+ #include <vector>
+ 
+ 

--- a/3rdparty/iio.patch
+++ b/3rdparty/iio.patch
@@ -1,0 +1,15 @@
+diff --git a/3rdparty/iio/iio.c b/3rdparty/iio/iio.c
+index 5bff3d8..67b06ac 100644
+--- a/3rdparty/iio/iio.c
++++ b/3rdparty/iio/iio.c
+@@ -535,7 +535,9 @@ int iio_type_id(size_t sample_size, bool ieeefp_sample, bool signed_sample)
+ 		switch(sample_size) {
+ 		case sizeof(float):       return IIO_TYPE_FLOAT;
+ 		case sizeof(double):      return IIO_TYPE_DOUBLE;
+-		case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#ifdef I_CAN_HAS_LONGDOUBLE
++		    case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#endif//I_CAN_HAS_LONGDOUBLE
+ 		case sizeof(float)/2:     return IIO_TYPE_HALF;
+ 		default: fail("bad float size %zu", sample_size);
+ 		}

--- a/3rdparty/imscript.patch
+++ b/3rdparty/imscript.patch
@@ -1,0 +1,15 @@
+diff --git a/3rdparty/imscript/src/iio.c b/3rdparty/imscript/src/iio.c
+index 2516713..8428556 100644
+--- a/3rdparty/imscript/src/iio.c
++++ b/3rdparty/imscript/src/iio.c
+@@ -535,7 +535,9 @@ int iio_type_id(size_t sample_size, bool ieeefp_sample, bool signed_sample)
+ 		switch(sample_size) {
+ 		case sizeof(float):       return IIO_TYPE_FLOAT;
+ 		case sizeof(double):      return IIO_TYPE_DOUBLE;
+-		case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#ifdef I_CAN_HAS_LONGDOUBLE
++		    case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#endif//I_CAN_HAS_LONGDOUBLE
+ 		case sizeof(float)/2:     return IIO_TYPE_HALF;
+ 		default: fail("bad float size %zu", sample_size);
+ 		}

--- a/3rdparty/mgm.patch
+++ b/3rdparty/mgm.patch
@@ -1,0 +1,15 @@
+diff --git a/3rdparty/mgm/iio/iio.c b/3rdparty/mgm/iio/iio.c
+index 4a678db..33de681 100644
+--- a/3rdparty/mgm/iio/iio.c
++++ b/3rdparty/mgm/iio/iio.c
+@@ -489,7 +489,9 @@ int iio_type_id(size_t sample_size, bool ieeefp_sample, bool signed_sample)
+ 		switch(sample_size) {
+ 		case sizeof(float):       return IIO_TYPE_FLOAT;
+ 		case sizeof(double):      return IIO_TYPE_DOUBLE;
+-		case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#ifdef I_CAN_HAS_LONGDOUBLE
++		    case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#endif//I_CAN_HAS_LONGDOUBLE
+ 		case sizeof(float)/2:     return IIO_TYPE_HALF;
+ 		default: fail("bad float size %zu", sample_size);
+ 		}

--- a/3rdparty/mgm_multi.patch
+++ b/3rdparty/mgm_multi.patch
@@ -1,0 +1,17 @@
+diff --git a/3rdparty/mgm_multi/iio/iio.c b/3rdparty/mgm_multi/iio/iio.c
+index 9f28831..7475497 100644
+--- a/3rdparty/mgm_multi/iio/iio.c
++++ b/3rdparty/mgm_multi/iio/iio.c
+@@ -511,8 +511,10 @@ int iio_type_id(size_t sample_size, bool ieeefp_sample, bool signed_sample)
+ 		switch(sample_size) {
+ 		case sizeof(float):       return IIO_TYPE_FLOAT;
+ 		case sizeof(double):      return IIO_TYPE_DOUBLE;
+-		case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
+-		case sizeof(float)/2:     return IIO_TYPE_HALF;
++		#ifdef I_CAN_HAS_LONGDOUBLE
++		    case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#endif//I_CAN_HAS_LONGDOUBLE
++	    case sizeof(float)/2:     return IIO_TYPE_HALF;
+ 		default: fail("bad float size %zu", sample_size);
+ 		}
+ 	} else {

--- a/3rdparty/sift.patch
+++ b/3rdparty/sift.patch
@@ -1,0 +1,28 @@
+diff --git a/3rdparty/sift/simd/LibImages/LibImages.cpp b/3rdparty/sift/simd/LibImages/LibImages.cpp
+index 6acbe4e..870d80b 100644
+--- a/3rdparty/sift/simd/LibImages/LibImages.cpp
++++ b/3rdparty/sift/simd/LibImages/LibImages.cpp
+@@ -10,8 +10,7 @@
+ #ifdef _OPENMP
+ #include <omp.h>
+ #endif
+-#include <xmmintrin.h>
+-#include <x86intrin.h>
++#include "../../sse2neon/sse2neon.h"
+ #include <cmath>
+ #include <algorithm>
+ #include <cstring>
+diff --git a/3rdparty/sift/simd/LibImages/LibImages.h b/3rdparty/sift/simd/LibImages/LibImages.h
+index 9918472..c8c5db1 100644
+--- a/3rdparty/sift/simd/LibImages/LibImages.h
++++ b/3rdparty/sift/simd/LibImages/LibImages.h
+@@ -5,8 +5,7 @@
+ #include <stdlib.h>
+ #include <string>
+ #include <vector>
+-#include <xmmintrin.h>
+-#include <x86intrin.h>
++#include "../../../sse2neon/sse2neon.h"
+ 
+ //! Local includes
+ 

--- a/3rdparty/tvl1flow.patch
+++ b/3rdparty/tvl1flow.patch
@@ -1,0 +1,15 @@
+diff --git a/3rdparty/tvl1flow/iio.c b/3rdparty/tvl1flow/iio.c
+index 9f28831..e27955e 100644
+--- a/3rdparty/tvl1flow/iio.c
++++ b/3rdparty/tvl1flow/iio.c
+@@ -511,7 +511,9 @@ int iio_type_id(size_t sample_size, bool ieeefp_sample, bool signed_sample)
+ 		switch(sample_size) {
+ 		case sizeof(float):       return IIO_TYPE_FLOAT;
+ 		case sizeof(double):      return IIO_TYPE_DOUBLE;
+-		case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#ifdef I_CAN_HAS_LONGDOUBLE
++		    case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
++		#endif//I_CAN_HAS_LONGDOUBLE
+ 		case sizeof(float)/2:     return IIO_TYPE_HALF;
+ 		default: fail("bad float size %zu", sample_size);
+ 		}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 addopts = --cov s2p --cov-report term-missing
 filterwarnings =
     ignore::rasterio.errors.NotGeoreferencedWarning
+testpaths = tests
 
 [coverage:run]
 branch = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+def pytest_sessionstart():
+    os.environ['PATH'] = os.environ['PATH'] + os.pathsep + "/opt/homebrew/Caskroom/miniconda/base/envs/s2p/lib"


### PR DESCRIPTION
This PR adds compilation support for Mac OS. The intention of the PR was to have a lightweight patch on top of the existing code that fixes all compilation errors on macs, without disturbing the compilation on Linux.

To make this work, the following are changed:
1. homebrew libraries are included in the correct C and C++ compilation env variables (for finding `libtiff` etc)
1. missing CPU instructions replaced by compatible ones
1. missing data types are guarded

Can be tested on this branch in s2p-pipelines: https://github.com/20treeAI/s2p_pipelines/tree/feat/mac


# Issues fixed

## Correct linking to homebrew libraries

Certain dependencies such as `libtiff` and `libpng` are installed with homebrew on macs, these were not found during the compilation. The following 4 flags are edited to included homebrew libraries:
```bash
 	export C_INCLUDE_PATH := ${C_INCLUDE_PATH}:/opt/homebrew/include
	export CPLUS_INCLUDE_PATH := ${CPLUS_INCLUDE_PATH}:/opt/homebrew/include
	export LIBRARY_PATH := ${LIBRARY_PATH}:/opt/homebrew/lib
	export LD_LIBRARY_PATH := ${LD_LIBRARY_PATH}:/opt/homebrew/lib
```

Without this, the compilation fails on missing headers such as `<png.h>`.

## Missing CPU instructions on Apple silicon

Addressed by hotpatching the submodules before compilation, this uses the header file [sse2neon.h](https://github.com/DLTcollab/sse2neon) to convert intel-specific flags to generic ones (specifically `XXXintrin.h`)

The makefile automatically applies the patches in `3rdparty`, which use the newly added `sse2neon` submodule. The makefile also uses the recommended `-march` flag.

Example:
```c++
diff --git a/3rdparty/sift/simd/LibImages/LibImages.h b/3rdparty/sift/simd/LibImages/LibImages.h
index 9918472..c8c5db1 100644
--- a/3rdparty/sift/simd/LibImages/LibImages.h
+++ b/3rdparty/sift/simd/LibImages/LibImages.h
@@ -5,8 +5,7 @@
 #include <stdlib.h>
 #include <string>
 #include <vector>
-#include <xmmintrin.h>
-#include <x86intrin.h>
+#include "../../../sse2neon/sse2neon.h"
```

Without this, compilation fails on errors such as these:

```bash
In file included from main.cpp:19:
In file included from ./LibImages/LibImages.h:8:
In file included from /Library/Developer/CommandLineTools/usr/lib/clang/15.0.0/include/xmmintrin.h:17:
/Library/Developer/CommandLineTools/usr/lib/clang/15.0.0/include/mmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
/Library/Developer/CommandLineTools/usr/lib/clang/15.0.0/include/mmintrin.h:37:5: error: use of undeclared identifier '__builtin_ia32_emms'; did you mean '__builtin_isless'?
    __builtin_ia32_emms();
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/math.h:507:10: note: '__builtin_isless' declared here
  return __builtin_isless((type)__x, (type)__y);
```

## Missing `long double` type on Apple silicon

`long double` is not supported, where needed, the switch cases are guarded with the CMAKE flag `I_CAN_HAS_LONGDOUBLE`.

Example:
```c++
diff --git a/3rdparty/mgm_multi/iio/iio.c b/3rdparty/mgm_multi/iio/iio.c
index 9f28831..7475497 100644
--- a/3rdparty/mgm_multi/iio/iio.c
+++ b/3rdparty/mgm_multi/iio/iio.c
@@ -511,8 +511,10 @@ int iio_type_id(size_t sample_size, bool ieeefp_sample, bool signed_sample)
 		switch(sample_size) {
 		case sizeof(float):       return IIO_TYPE_FLOAT;
 		case sizeof(double):      return IIO_TYPE_DOUBLE;
-		case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
-		case sizeof(float)/2:     return IIO_TYPE_HALF;
+		#ifdef I_CAN_HAS_LONGDOUBLE
+		    case sizeof(long double): return IIO_TYPE_LONGDOUBLE;
+		#endif//I_CAN_HAS_LONGDOUBLE
+	    case sizeof(float)/2:     return IIO_TYPE_HALF;
 		default: fail("bad float size %zu", sample_size);
 		}
```