### PR TITLE
feat: add sift_else_exogenous

### DIFF
--- a/s2p/config.py
+++ b/s2p/config.py
@@ -116,7 +116,7 @@ cfg['fusion_thresh'] = 3
 
 cfg['rpc_alt_range_scale_factor'] = 1
 
-# method to compute the disparity range: "sift", "exogenous", "wider_sift_exogenous", "fixed_pixel_range", "fixed_altitude_range"
+# method to compute the disparity range: "sift", "exogenous", "wider_sift_exogenous", "fixed_pixel_range", "fixed_altitude_range", "sift_else_exogenous"
 cfg['disp_range_method'] = "wider_sift_exogenous"
 cfg['disp_range_exogenous_low_margin'] = -10
 cfg['disp_range_exogenous_high_margin'] = +100

--- a/s2p/rectification.py
+++ b/s2p/rectification.py
@@ -182,8 +182,8 @@ def disparity_range(rpc1, rpc2, x, y, w, h, H1, H2, matches, cfg, A=None):
         disp: 2-uple containing the horizontal disparity range
     """
     # compute exogenous disparity range if needed
-    if cfg['disp_range_method'] in ['exogenous', 'wider_sift_exogenous']:
-        exogenous_disp = rpc_utils.exogenous_disp_range_estimation(rpc1, rpc2,
+    if 'exogenous' in cfg['disp_range_method']:
+        exogenous_disp = rpc_utils.exogenous_or_sift_disp_range_estimation(rpc1, rpc2,
                                                                    x, y, w, h,
                                                                    H1, H2, cfg, A,
                                                                    cfg['disp_range_exogenous_high_margin'],
@@ -192,7 +192,7 @@ def disparity_range(rpc1, rpc2, x, y, w, h, H1, H2, matches, cfg, A=None):
         print("exogenous disparity range:", exogenous_disp)
 
     # compute SIFT disparity range if needed
-    if cfg['disp_range_method'] in ['sift', 'wider_sift_exogenous']:
+    if 'sift' in cfg['disp_range_method']:
         if matches is not None and len(matches) >= 2:
             sift_disp = disparity_range_from_matches(matches, H1, H2, w, h, cfg['disp_range_extra_margin'])
         else:
@@ -219,6 +219,9 @@ def disparity_range(rpc1, rpc2, x, y, w, h, H1, H2, matches, cfg, A=None):
             disp = min(exogenous_disp[0], sift_disp[0]), max(exogenous_disp[1], sift_disp[1])
         else:
             disp = sift_disp or exogenous_disp
+
+    elif cfg['disp_range_method'] == 'sift_else_exogenous':
+        disp = sift_disp if sift_disp is not None else exogenous_disp
 
     elif cfg['disp_range_method'] == 'fixed_altitude_range':
         disp = alt_disp

--- a/s2p/rpc_utils.py
+++ b/s2p/rpc_utils.py
@@ -423,7 +423,7 @@ def alt_to_disp(rpc1, rpc2, x, y, alt, H1, H2, A=None):
     return disp
 
 
-def exogenous_disp_range_estimation(rpc1, rpc2, x, y, w, h, H1, H2, cfg, A=None,
+def exogenous_or_sift_disp_range_estimation(rpc1, rpc2, x, y, w, h, H1, H2, cfg, A=None,
                                     margin_top=0, margin_bottom=0):
     """
     Args:

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ extras_require = {
 }
 
 setup(name="s2p",
-      version="1.6.7",
+      version="1.6.8",
       description="Satellite Stereo Pipeline.",
       long_description=readme(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
* This introduces a new disparity range method, which always uses only sift if available and falls back to the exogenous DEM (or SRTM) if not.